### PR TITLE
Disable content decode

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -25,6 +25,9 @@ class Client extends \GuzzleHttp\Client
         }
         $stack = $config['handler'];
 
+        // Download file without decoding
+        $config['decode_content'] = false;
+
         // Timeouts
         $config['connect_timeout'] = 60; // 60 seconds
         $config['timeout'] = 15 * 60 * 60; // 15 minutes


### PR DESCRIPTION
Ticket: https://keboola.zendesk.com/agent/tickets/16592
Related issue: https://github.com/guzzle/guzzle/issues/2146#issuecomment-424515055

Internal error:
` "Unrecognized content encoding type. libcurl understands deflate, gzip content encodings."`