### PR TITLE
Catch encoding error

### DIFF
--- a/src/Exception/EncodingException.php
+++ b/src/Exception/EncodingException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\HttpExtractor\Exception;
+
+class EncodingException extends \Exception
+{
+
+}


### PR DESCRIPTION
Changes:
- When server send some invalid `Content-Encoding: UTF-8`, we will retry request with `decode_content = false`.